### PR TITLE
passed id to routes pastel when show, destroy and update

### DIFF
--- a/src/controllers/PastelController.js
+++ b/src/controllers/PastelController.js
@@ -8,6 +8,11 @@ module.exports = {
     return res.json(pastel);
   },
 
+  async show(req, res) {
+    const pastel = await Pastel.findById(req.params.id);
+    return res.json(pastel);
+  },
+
   async store(req, res) {
     const pastel = await Pastel.create(req.body);
     return res.json(pastel);

--- a/src/routes.js
+++ b/src/routes.js
@@ -6,6 +6,8 @@ const PastelController = require('./controllers/PastelController');
 
 routes.get('/pastel', PastelController.index);
 routes.post('/pastel', PastelController.store);
-routes.put('/pastel', PastelController.update);
+routes.get('/pastel/:id', PastelController.show);
+routes.put('/pastel/:id', PastelController.update);
+routes.delete('/pastel/:id', PastelController.destroy);
 
 module.exports = routes;


### PR DESCRIPTION
# Passando os id para as rotas

Estava faltando passar os ID para as rotas de remoção, atualização e seleção de Pastéis.